### PR TITLE
update link to work with visualstudio.com

### DIFF
--- a/scripts/app.ts
+++ b/scripts/app.ts
@@ -40,7 +40,7 @@ function createHtmlLink(link: string, text: number | string) {
 
 function createWorkItemHtmlLink(id: number): string {
     var context = VSS.getWebContext();
-    var link = `/${context.collection.name}/${context.project.name}/_workitems/edit/${id}`;
+    var link = `${context.collection.uri}${context.project.name}/_workitems/edit/${id}`;
     return createHtmlLink(link, id);
 }
 

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "vsts-extension-split-work",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "name": "Split!",
     "scopes": [
         "vso.work",


### PR DESCRIPTION
Previous fix for link wasn't correct. It was broken if users had an "old" visualstudio.com style url.  The url for hosted accounts is in two different format - myaccount.visualstudio.com/Project or dev.azure.com/myaccount/Project. 

This PR changes so that we use the collection uri, which is myaccount.visualstudio.com or dev.azure.com/myaccount or myOnPrem/MyCollection.  All can have project appended to them to create a valid url. 