### PR TITLE
Include custom closed states and required fields in split

### DIFF
--- a/details.md
+++ b/details.md
@@ -1,11 +1,11 @@
 **Split!** enables teams to easily continue unfinished work items into the next sprint by “splitting” the work item into a new card in the next sprint. 
 
 ## What's special about Split?
-* Smart detects incomplete tasks
+* Smart detects incomplete tasks - even for processes with custom states
 * Defaults split work item to the next iteration
 * Maintains parent link
 * Retains all attachments
-* Copies description to new work item
+* Copies description, repro steps, acceptance criteria and any required fields to new work item
 * Inserts comment revision with links detailing the split operation 
 * Optionally copies all tags
 

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -15,11 +15,6 @@
                 stdout: true,
                 stderr: true
             },
-            publish: {
-                command: "tfx extension publish --manifest-globs vss-extension.json",
-                stdout: true,
-                stderr: true
-            },
             publishlocal: {
                 command: "tfx extension publish --manifest-globs vss-extension.json --service-url http://localhost:8080/tfs/",
                 stdout: true,

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,11 @@
 ## Split! ##
 
+#### Customizing this extension ####
+
+This extension does a best effort to copy relevant information - including Title, AssignedTo, AreaPath, Description and any required fields. You may want additional custom fields to copy on split. We cannot support everyone's custom configuration, so we've tried to make it easy to clone this repo and create your own version of this extension. 
+
+If you think your change would benefit others - please contribute to the master extension! 
+
 ### Structure ###
 
 ```
@@ -13,20 +19,24 @@ index.html          - Main entry point
 dialog.html         - Dialog html
 vss-extension.json  - Extension manifest
 ```
-
 #### Grunt ####
 
 Three basic `grunt` tasks are defined:
 
 * `build` - Compiles TS files in `scripts` folder
 * `package` - Builds the vsix package
-* `publish` - Publishes the extension to the marketplace using `tfx-cli`
+* `publishLocal` - Publishes the extension to your local box marketplace using `tfx-cli`
 
 Note: To avoid `tfx` prompting for your token when publishing, login in beforehand using `tfx login` and the service uri of ` https://app.market.visualstudio.com`.
 
-#### Including framework modules ####
+#### Setup for custom extensions ####
 
-The VSTS framework is setup to initialize the requirejs AMD loader, so just use `import Foo = require("foo")` to include framework modules.
+1. Run npm install 
+2. Look for "Hello custom extension author" for common extension customization points
+3. Change the publisher in the vss-extension.json
+4. grunt build
+5. grunt package
+6. Upload to your on-prem instance via http://myAzureDevopsServer/_gallery/manage
 
 #### VS Code ####
 

--- a/scripts/app.ts
+++ b/scripts/app.ts
@@ -7,7 +7,7 @@ import TFS_Wit_Services = require("TFS/WorkItemTracking/Services");
 import TFS_Work_Contracts = require("TFS/Work/Contracts");
 import TFS_Work_Client = require("TFS/Work/RestClient");
 
-import {CoreFields} from "./constants";
+import { CoreFields, AdditionalFields } from "./constants";
 
 function createFieldPatchBlock(field: string, value: string): any {
     return {
@@ -44,8 +44,7 @@ function createWorkItemHtmlLink(id: number): string {
 
 function removeLinks(workItem: TFS_Wit_Contracts.WorkItem, linkedWorkItemIds: number[], targetId: number): IPromise<TFS_Wit_Contracts.WorkItem> {
     if (!linkedWorkItemIds || linkedWorkItemIds.length === 0) {
-        return new Promise( function (resolve, reject)
-        {
+        return new Promise(function (resolve, reject) {
             resolve(workItem);
         });
     }
@@ -71,7 +70,7 @@ function removeLinks(workItem: TFS_Wit_Contracts.WorkItem, linkedWorkItemIds: nu
 
 function addRelations(workItem: TFS_Wit_Contracts.WorkItem, relations: TFS_Wit_Contracts.WorkItemRelation[]): IPromise<TFS_Wit_Contracts.WorkItem> {
     if (!relations || relations.length === 0) {
-        return new Promise(function (resolve, reject){
+        return new Promise(function (resolve, reject) {
             return workItem;
         });
     }
@@ -120,12 +119,33 @@ function updateIterationPath(childIdsToMove: number[], iterationPath: string): I
     return Promise.all(promises);
 }
 
-function createWorkItem(workItem: TFS_Wit_Contracts.WorkItem, copyTags: boolean, title?: string, iterationPath?: string): IPromise<TFS_Wit_Contracts.WorkItem> {
-    var patchDocument = [];
-    var fieldsToCopy = [CoreFields.Title, CoreFields.AssignedTo, CoreFields.IterationPath, CoreFields.AreaPath, CoreFields.Description];
-    if (copyTags){
+async function createWorkItem(workItem: TFS_Wit_Contracts.WorkItem, copyTags: boolean, title?: string, iterationPath?: string): Promise<TFS_Wit_Contracts.WorkItem> {
+    const context = VSS.getWebContext();
+    let patchDocument = [];
+    const currentWorkItemType = workItem.fields[CoreFields.WorkItemType];
+
+    /* Hello custom extension author - Add your custom field ref name here!*/
+    var fieldsToCopy = [CoreFields.Title, CoreFields.AssignedTo, CoreFields.IterationPath, CoreFields.AreaPath, CoreFields.Description,
+        AdditionalFields.AcceptanceCriteria, AdditionalFields.ReproSteps, AdditionalFields.SystemInfo];
+
+    // Copy any fields that are required for this work item 
+    const workItemTypeInfo = await TFS_Wit_Client.getClient().getWorkItemType(context.project.name, currentWorkItemType);
+    workItemTypeInfo.fields.forEach(f => {        
+        // Don't include iteration related fields or state, we don't want that copied from the current work item        
+        const isIgnoredField = f.referenceName === AdditionalFields.IterationId || f.referenceName === CoreFields.State; 
+        const isRequiredField = f.alwaysRequired;
+        if (isRequiredField && !isIgnoredField ){
+            if (fieldsToCopy.indexOf(f.referenceName) === -1) {
+                fieldsToCopy.push(f.referenceName);
+            }
+        }
+    });
+
+    if (copyTags) {
         fieldsToCopy.push(CoreFields.Tags);
     }
+
+    // Add all fields to the patch document that will be used to create the work item
     fieldsToCopy.forEach(field => {
         if (field === CoreFields.Title && title && title.length > 0) {
             patchDocument.push(createFieldPatchBlock(field, title));
@@ -140,7 +160,6 @@ function createWorkItem(workItem: TFS_Wit_Contracts.WorkItem, copyTags: boolean,
     var comment = `This work item was ${createHtmlLink("http://aka.ms/split", "split")} from work item ${createWorkItemHtmlLink(workItem.id)}: ${workItem.fields[CoreFields.Title]}`;
     patchDocument.push(createFieldPatchBlock(CoreFields.History, comment));
 
-    var context = VSS.getWebContext();
     return TFS_Wit_Client.getClient().createWorkItem(patchDocument, context.project.name, workItem.fields[CoreFields.WorkItemType]);
 }
 
@@ -174,11 +193,11 @@ function findNextIteration(sourceWorkItem: TFS_Wit_Contracts.WorkItem): IPromise
     });
 }
 
-function peformSplit(id: number, childIdsToMove: number[], copyTags : boolean, title?: string): IPromise<TFS_Wit_Contracts.WorkItem> {
-    return TFS_Wit_Client.getClient().getWorkItem(id, null, null, <any>"all" /*TFS_Wit_Contracts.WorkItemExpand.All*/)    // TODO: Bug - TFS_Wit_Contracts.WorkItemExpand.All should be a string value or REST API should handle enum value.
+function peformSplit(id: number, childIdsToMove: number[], copyTags: boolean, title?: string): IPromise<TFS_Wit_Contracts.WorkItem> {
+    return TFS_Wit_Client.getClient().getWorkItem(id, null, null, TFS_Wit_Contracts.WorkItemExpand.All)
         .then((sourceWorkItem: TFS_Wit_Contracts.WorkItem) => {
             return findNextIteration(sourceWorkItem).then(iterationPath => {
-                return createWorkItem(sourceWorkItem, copyTags, title, iterationPath ).then((targetWorkItem) => {
+                return createWorkItem(sourceWorkItem, copyTags, title, iterationPath).then((targetWorkItem) => {
                     return updateLinkRelations(sourceWorkItem, targetWorkItem, childIdsToMove).then(() => {
                         return updateIterationPath(childIdsToMove, iterationPath).then(() => {
                             return targetWorkItem;
@@ -214,14 +233,13 @@ function showDialog(workItemId: number) {
         getDialogResult: () => {
             return _contribution.getDetails();
         },
-        okCallback: (details:  { ids: number[], title: string, shouldOpenNewWorkItem: boolean, shouldCopyTags: boolean })  =>
-        {
+        okCallback: (details: { ids: number[], title: string, shouldOpenNewWorkItem: boolean, shouldCopyTags: boolean }) => {
             if (details.ids && details.ids.length > 0) {
                 peformSplit(workItemId, details.ids, details.shouldCopyTags, details.title).then((splitWorkItem: TFS_Wit_Contracts.WorkItem) => {
                     _dialog.close();
 
                     if (details.shouldOpenNewWorkItem) {
-                        VSS.getService(TFS_Wit_Services.WorkItemFormNavigationService.contributionId).then((service : TFS_Wit_Services.IWorkItemFormNavigationService) => {
+                        VSS.getService(TFS_Wit_Services.WorkItemFormNavigationService.contributionId).then((service: TFS_Wit_Services.IWorkItemFormNavigationService) => {
                             service.openWorkItem(splitWorkItem.id);
                         });
                     }
@@ -233,9 +251,9 @@ function showDialog(workItemId: number) {
     VSS.getService(VSS.ServiceIds.Dialog).then((dialogSvc: IHostDialogService) => {
         var extensionCtx = VSS.getExtensionContext();
         var splitWorkDialogContributionId = extensionCtx.publisherId + "." + extensionCtx.extensionId + ".vsts-extension-split-work-dialog";
-        dialogSvc.openDialog(splitWorkDialogContributionId , dialogOptions).then((dialog: IExternalDialog) => {
+        dialogSvc.openDialog(splitWorkDialogContributionId, dialogOptions).then((dialog: IExternalDialog) => {
             _dialog = dialog;
-            dialog.getContributionInstance(splitWorkDialogContributionId ).then((contribution: any) => {
+            dialog.getContributionInstance(splitWorkDialogContributionId).then((contribution: any) => {
                 _contribution = contribution;
                 contribution.startSplit(workItemId).then(enable => {
                     if (enable) {

--- a/scripts/constants.ts
+++ b/scripts/constants.ts
@@ -9,3 +9,10 @@ export module CoreFields {
     export var WorkItemType = "System.WorkItemType";
     export var Tags = "System.Tags";
 }
+
+export module AdditionalFields {
+    export var AcceptanceCriteria = "Microsoft.VSTS.Common.AcceptanceCriteria"; 
+    export var ReproSteps = "Microsoft.VSTS.TCM.ReproSteps"; 
+    export var SystemInfo = "Microsoft.VSTS.TCM.SystemInfo";
+    export var IterationId = "System.IterationId"; 
+}

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "vsts-extension-split-work",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "name": "Split!",
     "scopes": [
         "vso.work",


### PR DESCRIPTION
The current version of the extension doesn't handle customization of process very well.  This PR add in several asked for features... 

1. #16 - Read "Completed" and "Removed" meta-states to determine which states should stay and which should split. These states can be customized or renamed. Updating the code to not look for hard coded state names, instead inspect the work item type states to find the ones matching "Completed" and "Removed" 
![image](https://user-images.githubusercontent.com/9122518/60374624-2aa60180-99ba-11e9-8931-f0152cfdf8bd.png)

2. #4 Include required fields in the update. Currently, the extension create work item silently if required fields are present. Read all work item type's fields, filter for the required, and include those in the update. Do not include IterationId or State. Both are required but we want them to be set to the next iteration or default. 
